### PR TITLE
Fix ReST syntax errors in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Usage
 High-level usage is really straightforward. To render normal CommonMark
 markdown:
 
-..code-block:: python
+.. code-block:: python
 
     import cmarkgfm
 
@@ -31,7 +31,7 @@ markdown:
 
 To render GitHub-flavored markdown:
 
-..code-block:: python
+.. code-block:: python
 
     import cmarkgfm
 


### PR DESCRIPTION
(BTW the code blocks for CommonMark and GitHub Flavoured Markdown are identical AFAICS.  Is that intentional?)