### PR TITLE
There's a github_flavored_markdown_to_html()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ To render GitHub-flavored markdown:
 
     import cmarkgfm
 
-    html = cmarkgfm.markdown_to_html(markdown_text)
+    html = cmarkgfm.github_flavored_markdown_to_html(markdown_text)
 
 
 Contributing


### PR DESCRIPTION
I think the examples are supposed to be different, and I see a github_flavored_markdown_to_html() in cmark.py.