### PR TITLE
build_cmark.py: fix _compiler_type detection for mingw32

### DIFF
--- a/src/cmarkgfm/build_cmark.py
+++ b/src/cmarkgfm/build_cmark.py
@@ -54,12 +54,14 @@ def _compiler_type():
 
 
 COMPILER_TYPE = _compiler_type()
-if COMPILER_TYPE == 'unix':
+if COMPILER_TYPE in {'unix', 'mingw32'}:
     EXTRA_COMPILE_ARGS = ['-std=c99']
     GENERATED_SRC_DIR = UNIX_GENERATED_SRC_DIR
 elif COMPILER_TYPE == 'msvc':
     EXTRA_COMPILE_ARGS = ['/TP']
     GENERATED_SRC_DIR = WIN_GENERATED_SRC_DIR
+else:
+    raise AssertionError("unsupported compiler: %s" % COMPILER_TYPE)
 
 
 ffibuilder = cffi.FFI()


### PR DESCRIPTION
When compiling with gcc on windows we need to use the unix generated source dir, and avoid passing unsupported `/TP` flag.

see https://github.com/jonparrott/cmarkgfm/issues/2#issuecomment-378542258
