### PR TITLE
Include cmark licensing info in sdist tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,6 @@ recursive-include src/cmarkgfm *.h
 recursive-include third_party/cmark/src *.c *.h *.inc
 recursive-include third_party/cmark/extensions *.c *.h *.inc
 recursive-include generated *.h
+
+# Include cmark licensing information
+include third_party/cmark/COPYING


### PR DESCRIPTION
Hi!

I'm looking into packaging python-cmarkgfm for Debian. To do so, I need to do a thorough review of the licensing and copyright information of the package's source code.

Your MANIFEST.in file excludes the top-level license and copyright information from the cmark directory (https://github.com/github/cmark/blob/bf28ef6e7e949157ab85a5e4a3ea9107e17497b9/COPYING), which makes the redistributability of your PyPI-published tarballs questionable.

This trivial patch includes the upstream COPYING file in the sdist tarballs.

Thanks for considering!